### PR TITLE
chore(deps): update renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,9 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
-  "prHourlyLimit": 0,
-  "prConcurrentLimit": 0,
-  "pre-commit": {
-    "enabled": true
-  }
-}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,12 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["config:best-practices"],
+  prHourlyLimit: 0,
+  prConcurrentLimit: 0,
+  "pre-commit": {
+    enabled: true,
+  },
+  // TODO: Remove this once Renovate support pnpm-lock files
+  // https://github.com/renovatebot/renovate/issues/21438
+  rangeStrategy: "pin",
+}


### PR DESCRIPTION
Move from the `config:base` present to `config:best-practices`, and introduced a workaround for Renovate's lack of support for pnpm lock files.