### PR TITLE
chore: change range strategy for node

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,4 +9,10 @@
   // TODO: Remove this once Renovate support pnpm-lock files
   // https://github.com/renovatebot/renovate/issues/21438
   rangeStrategy: "pin",
+  packageRules: [
+    {
+      matchPackagePatterns: ["node"],
+      rangeStrategy: "auto",
+    },
+  ],
 }


### PR DESCRIPTION
The range strategy was adjusted for a pnpm-lock issue, which does not apply to node itself.