### PR TITLE
chore(deps): combine Renovate dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,6 +13,7 @@
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
   "automerge": true,
+  "rebaseWhen": "conflicted",
   "packageRules": [
     {
       "matchPackageNames": ["taiki-e/install-action"],

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
         run: mise run build
 
       - name: Deploy
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,12 +24,12 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: jdx/mise-action@v4.0.1
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151  # v4.0.1
 
       - name: Cache Cargo registry
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/registry
@@ -38,7 +38,7 @@ jobs:
           restore-keys: cargo-
 
       - name: Cache build artifacts
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: target
           key: target-release-${{ hashFiles('Cargo.lock', 'src/**', 'style/**', 'content/**') }}
@@ -48,7 +48,7 @@ jobs:
         run: mise run build
 
       - name: Deploy
-        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0  # v4
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: jdx/mise-action@v4.0.1
 
       - name: Cache Cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ~/.cargo/registry
@@ -38,7 +38,7 @@ jobs:
           restore-keys: cargo-
 
       - name: Cache build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: target
           key: target-release-${{ hashFiles('Cargo.lock', 'src/**', 'style/**', 'content/**') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,19 +28,19 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
-      - uses: crate-ci/committed@v1.1.11
+      - uses: crate-ci/committed@faeed42f2e10c244533a01525f13c4d8b6ce383f  # v1.1.11
 
   prek:
     name: Pre-commit hooks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: jdx/mise-action@v4.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151  # v4.0.1
       - name: Cache prek environments
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ~/.cache/prek
           key: prek-${{ hashFiles('prek.toml') }}
@@ -53,16 +53,16 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: jdx/mise-action@v4.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151  # v4.0.1
       - run: cargo clippy --all-targets --all-features -- -D warnings
 
   format:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: jdx/mise-action@v4.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151  # v4.0.1
       - run: rustup component add rustfmt --toolchain nightly
       - run: cargo +nightly fmt --all --check
 
@@ -70,15 +70,15 @@ jobs:
     name: Machete
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: jdx/mise-action@v4.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151  # v4.0.1
       - run: cargo machete
 
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: jdx/mise-action@v4.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151  # v4.0.1
       - name: Run unit tests
         run: mise run test:nextest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - uses: jdx/mise-action@v4.0.1
       - name: Cache prek environments
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.cache/prek
           key: prek-${{ hashFiles('prek.toml') }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,10 @@ leptos_router = { version = "0.8" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 stylance = "0.8"
-toml = { version = "1.0", default-features = false, features = ["parse"] }
+toml = { version = "1.0", default-features = false, features = [
+  "parse",
+  "serde"
+] }
 wasm-bindgen = "0.2"
 
 [dev-dependencies]
@@ -41,7 +44,10 @@ pulldown-cmark = { version = "0.13", default-features = false, features = [
   "html"
 ] }
 serde = { version = "1", features = ["derive"] }
-toml = { version = "1.0", default-features = false, features = ["parse"] }
+toml = { version = "1.0", default-features = false, features = [
+  "parse",
+  "serde"
+] }
 
 [target]
   [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -51,7 +57,7 @@ toml = { version = "1.0", default-features = false, features = ["parse"] }
   leptos_config = { version = "0.8" }
   reqwest = { version = "0.13", default-features = false, features = [
     "json",
-    "rustls-tls"
+    "rustls"
   ] }
   tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ toml = { version = "0.8", default-features = false, features = ["parse"] }
   chrono = { version = "0.4", features = ["serde"] }
   leptos_axum = { version = "0.8" }
   leptos_config = { version = "0.8" }
-  reqwest = { version = "0.12", default-features = false, features = [
+  reqwest = { version = "0.13", default-features = false, features = [
     "json",
     "rustls-tls"
   ] }
@@ -61,7 +61,7 @@ toml = { version = "0.8", default-features = false, features = ["parse"] }
   getrandom = { version = "0.4", features = ["wasm_js"] }
   getrandom03 = { package = "getrandom", version = "0.4", features = ["wasm_js"] }
   leptos_axum = { version = "0.8", default-features = false, features = ["wasm"], optional = true }
-  reqwest = { version = "0.12", default-features = false, features = ["json"], optional = true }
+  reqwest = { version = "0.13", default-features = false, features = ["json"], optional = true }
   send_wrapper = { version = "0.6", optional = true }
   tower = { version = "0.5", default-features = false, features = ["util"], optional = true }
   # SSR-only: not needed for hydrate/browser builds (prevents wasm-streams duplicate

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ toml = { version = "1.0", default-features = false, features = ["parse"] }
 wasm-bindgen = "0.2"
 
 [dev-dependencies]
-pretty_assertions = "1"
+pretty_assertions = "=1.4.1"
 
 [build-dependencies]
 pulldown-cmark = { version = "0.13", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ leptos_router = { version = "0.8" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 stylance = "0.8"
-toml = { version = "0.8", default-features = false, features = ["parse"] }
+toml = { version = "1.0", default-features = false, features = ["parse"] }
 wasm-bindgen = "0.2"
 
 [dev-dependencies]
@@ -41,7 +41,7 @@ pulldown-cmark = { version = "0.13", default-features = false, features = [
   "html"
 ] }
 serde = { version = "1", features = ["derive"] }
-toml = { version = "0.8", default-features = false, features = ["parse"] }
+toml = { version = "1.0", default-features = false, features = ["parse"] }
 
 [target]
   [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {},
   "devDependencies": {
-    "@playwright/test": "^1.52.0",
+    "@playwright/test": "1.60.0",
     "@types/node": "^24.0.0",
-    "typescript": "^6.0.0"
+    "typescript": "6.0.3"
   }
 }


### PR DESCRIPTION
## Summary

Combines all open Renovate dependency update PRs into a single PR:

- **#1399** `pin dependencies` — pins action SHAs, simplifies CI completion checks, pins playwright/typescript
- **#1402** `reqwest 0.13` — update Rust crate reqwest
- **#1404** `actions/cache v5` — upgrade GitHub Actions cache action
- **#1405** `cloudflare/wrangler-action v4` — upgrade Wrangler deploy action
- **#1408** `toml v1` — update Rust crate toml (supersedes #1403 toml 0.9)

Also includes a renovate config fix (`rebaseWhen: "conflicted"`) so future Renovate PRs only rebase when there's an actual merge conflict, not on every push to main.

**Note:** PR #1403 (toml 0.9) is superseded and can be closed.

## Conflict resolutions

- `actions/cache`: kept v5 SHA (from #1404) over pin-deps' v4 SHA
- `cloudflare/wrangler-action`: kept v4 SHA (from #1405) over pin-deps' v3 SHA
- `e2e/package.json` `@types/node`: kept `^24.0.0` (from main's #1406 upgrade) rather than pin-deps' outdated `20.19.41` pin

## Test plan

- [ ] CI passes (test + deploy workflows)
- [ ] Close superseded PR #1403 (toml 0.9)