### PR TITLE
fix(deps): revert getrandom03 alias to v0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ toml = { version = "1.0", default-features = false, features = [
   axum = { version = "0.8", default-features = false, optional = true }
   chrono = { version = "0.4", features = ["serde", "wasmbind"] }
   getrandom = { version = "0.4", features = ["wasm_js"] }
-  getrandom03 = { package = "getrandom", version = "0.4", features = ["wasm_js"] }
+  getrandom03 = { package = "getrandom", version = "0.3", features = ["wasm_js"] }
   leptos_axum = { version = "0.8", default-features = false, features = ["wasm"], optional = true }
   reqwest = { version = "0.13", default-features = false, features = ["json"], optional = true }
   send_wrapper = { version = "0.6", optional = true }


### PR DESCRIPTION
## Summary

- Renovate bumped the `getrandom03` wasm32 alias from `0.3` → `0.4` in #1401
- This made it resolve to the same crate+version as the direct `getrandom = "0.4"` dependency
- Cargo rejects two entries with different names resolving to the same crate+version, breaking CI

## Test plan

- [ ] CI build passes (wasm32 hydrate + SSR targets)