### PR TITLE
fix: redirect legacy /static/* URLs to canonical paths

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,2 @@
+# Preserve legacy /static/* asset URLs from the old website.
+/static/* /:splat 301


### PR DESCRIPTION
The old website served assets under `/static/images/`, `/static/projects/`, etc. A `_redirects` rule at the asset layer issues a 301 before the Worker is invoked, preserving any inbound links without worker-side logic.