### PR TITLE
fix(deps): unblock wasm32 SSR build and collate Renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,6 +18,12 @@
     {
       "matchPackageNames": ["taiki-e/install-action"],
       "schedule": "* 0-4 * * 1"
+    },
+    {
+      "description": "Pinned to =0.8.3 in Cargo.toml: worker >=0.8.4 pulls wasm-streams 0.6, which collides with leptos server_fn's 0.5 (duplicate wasm-bindgen symbols, breaking the wasm32 SSR link). Re-enable once server_fn moves to wasm-streams 0.6.",
+      "matchManagers": ["cargo"],
+      "matchPackageNames": ["worker"],
+      "enabled": false
     }
   ]
 }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,8 +24,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925  # v4.1.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d  # v4.2.0
 
       - name: Build
         run: mise run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
       - uses: crate-ci/committed@faeed42f2e10c244533a01525f13c4d8b6ce383f  # v1.1.11
@@ -37,10 +37,10 @@ jobs:
     name: Pre-commit hooks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925  # v4.1.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d  # v4.2.0
       - name: Cache prek environments
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8  # v6
         with:
           path: ~/.cache/prek
           key: prek-${{ hashFiles('prek.toml') }}
@@ -53,7 +53,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6  # v1.16.1
         with:
           components: clippy
@@ -69,7 +69,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6  # v1.16.1
         with:
           toolchain: nightly
@@ -80,17 +80,17 @@ jobs:
     name: Machete
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925  # v4.1.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d  # v4.2.0
       - run: cargo machete
 
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6  # v1.16.1
-      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925  # v4.1.0
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d  # v4.2.0
       - name: Install WebAssembly target
         run: rustup target add wasm32-unknown-unknown
       - name: Run unit tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ toml = { version = "1.0", default-features = false, features = [
   tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"] }
 
   [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-  wasm-bindgen-test = "=0.3.73"
+  wasm-bindgen-test = "=0.3.76"
 
   [target.'cfg(target_arch = "wasm32")'.dependencies]
   axum = { version = "0.8", default-features = false, optional = true }
@@ -144,7 +144,11 @@ toml = { version = "1.0", default-features = false, features = [
   # SSR-only: not needed for hydrate/browser builds (prevents wasm-streams duplicate
   # symbol errors — reqwest and worker each bring a different version).
   web-sys = { version = "0.3", features = ["Clipboard", "Navigator", "Window"] }
-  worker = { version = "0.8", features = ["axum", "http"], optional = true }
+  # Pinned: worker >=0.8.4 upgrades its wasm-streams dependency to 0.6, while
+  # leptos' server_fn still requires 0.5. Both export the same (un-namespaced)
+  # wasm-bindgen symbols, so linking the wasm32 SSR binary fails with duplicate
+  # symbol errors. Unpin once server_fn moves to wasm-streams 0.6.
+  worker = { version = "=0.8.3", features = ["axum", "http"], optional = true }
 
 [features]
 hydrate = ["dep:console_error_panic_hook", "leptos/hydrate"]

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {},
   "devDependencies": {
-    "@playwright/test": "1.60.0",
-    "@types/node": "24.13.1",
+    "@playwright/test": "1.61.0",
+    "@types/node": "24.13.2",
     "typescript": "6.0.3"
   }
 }


### PR DESCRIPTION
## Why

CI resolves dependencies fresh on every run (`Cargo.lock` is gitignored), so it
started picking up `worker` 0.8.4+, which bumped its `wasm-streams` dependency to
0.6 while leptos' `server_fn` still requires 0.5. Both versions export the same
un-namespaced `wasm-bindgen` symbols (`intounderlyingsource_*`), so linking the
wasm32 SSR test/deploy binary failed with **duplicate symbol** errors.

This broke the `Test` job (and `Deploy`) on **every** PR regardless of its
contents, which is why the Renovate PRs piled up — they fail CI and so never
auto-merge.

## Fix

- Pin `worker = "=0.8.3"` (the last release on `wasm-streams` 0.5) in `Cargo.toml`,
  with a comment explaining when to unpin.
- Add a Renovate rule disabling `worker` updates so it doesn't keep reopening a
  doomed bump PR (re-enable once `server_fn` moves to `wasm-streams` 0.6).

## Collated Renovate updates

Bundled here to avoid the per-PR CI cost (closes the six open Renovate PRs):

| PR | Update |
|----|--------|
| #1425 | `wasm-bindgen-test` 0.3.73 → 0.3.76 |
| #1423 | `@types/node` 24.13.1 → 24.13.2 |
| #1426 | `@playwright/test` 1.60.0 → 1.61.0 |
| #1427 | `actions/checkout` v6 → v7 |
| #1428 | `actions/cache` v5 → v6 |
| #1424 | `jdx/mise-action` v4.1.0 → v4.2.0 |

## Verification

Run locally with a freshly-resolved lockfile (matching CI's no-lockfile behaviour):

- `cargo nextest run --features ssr` → 68 passed
- `cargo test --target wasm32-unknown-unknown --features hydrate --tests` → pass
- `cargo test --target wasm32-unknown-unknown --features ssr --tests` → pass (was failing)
- `cargo clippy` native SSR / wasm hydrate / wasm SSR → clean