### PR TITLE
chore: exclude aube lockfiles from yamlfix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,6 @@ and gotchas that are easy to get wrong.
 - **Scripts run via `tsx`** (`aubx tsx scripts/…`). Node's native TS runner
   chokes on the attribute-less JSON imports the lib modules use; `tsx` handles
   them.
-- **The generated lockfiles are formatted artifacts.** `aube-lock.yaml` is
-  excluded from `typos` (it would "correct" package names/hashes) and is
-  yamlfix-formatted; after any `aube install`, let the yamlfix hook reformat
-  before committing.
+- **The generated lockfiles are machine-owned artifacts.** `aube-lock.yaml` is
+  excluded from both `typos` (it would "correct" package names/hashes) and
+  `yamlfix`; commit it exactly as the package manager wrote it.

--- a/mise.toml
+++ b/mise.toml
@@ -19,7 +19,7 @@ description = "Check formatting (biome, tombi, yamlfix)"
 run = [
   "biome format .",
   "tombi format --check .",
-  "yamlfix -c {{cwd}}/.yamlfix.toml --check .",
+  "yamlfix -c {{cwd}}/.yamlfix.toml --exclude '**/aube-lock.yaml' --check .",
 ]
 
 [tasks."format:fix"]
@@ -27,7 +27,7 @@ description = "Apply formatting fixes (biome, tombi, yamlfix)"
 run = [
   "biome format --write .",
   "tombi format .",
-  "yamlfix -c {{cwd}}/.yamlfix.toml .",
+  "yamlfix -c {{cwd}}/.yamlfix.toml --exclude '**/aube-lock.yaml' .",
 ]
 
 [tasks.lint]

--- a/prek.toml
+++ b/prek.toml
@@ -32,7 +32,11 @@ hooks = [
 repo = "https://github.com/lyz-code/yamlfix"
 rev = "1.19.1"
 hooks = [
-  { id = "yamlfix", args = ["--config-file=.yamlfix.toml"] },
+  {
+    id = "yamlfix",
+    args = ["--config-file=.yamlfix.toml"],
+    exclude = "(^|/)aube-lock\\.yaml$"
+  },
 ]
 
 [[repos]]


### PR DESCRIPTION
`aube-lock.yaml` (root and `e2e/`) is a generated artifact owned by the package manager. Running yamlfix over it produced churn on every install for no benefit, and risked the formatter disagreeing with whatever the tool writes next.

yamlfix has no config-file exclude — `YamlfixConfig` only carries formatting options (`line_length`, `whitelines`, …), and `--exclude` is parsed solely by the CLI entrypoint. `YAMLFIX_EXCLUDE` via `--env-prefix` doesn't work either, since it populates that same model. So the exclusion has to be applied per invocation site:

- **`mise.toml`** — `--exclude '**/aube-lock.yaml'` on the `format` and `format:fix` tasks. The recursive glob covers the `e2e/` workspace lockfile as well as the root one.
- **`prek.toml`** — `exclude = "(^|/)aube-lock\\.yaml$"` on the yamlfix hook.
- **`CLAUDE.md`** — the lockfile gotcha said the file *is* yamlfix-formatted; updated to match.

The remaining gap: a bare `yamlfix .` from an IDE integration still has no exclusion to pick up. Nothing in the tool supports that today — flagging it rather than papering over it.

## Verification

- `yamlfix -c .yamlfix.toml --exclude '**/aube-lock.yaml' --check .` — no `aube-lock` entries; without the flag, both lockfiles appear.
- `prek run yamlfix --files aube-lock.yaml e2e/aube-lock.yaml .github/workflows/test.yml` — passes, lockfiles untouched.
- `tombi lint prek.toml` passes; full pre-commit suite green on the commit.

`mise run format` still exits non-zero locally, but only over untracked `.playwright-mcp/` scratch files — pre-existing and unrelated to this change.