### PR TITLE
fix(ci): make the test completion gate actually block

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,16 @@ jobs:
       - check
       - test
       - e2e
-    if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+    if: ${{ always() }}
     steps:
-      - run: exit 1
+      - name: Verify every required job succeeded
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          echo "One or more required jobs did not succeed:"
+          echo "$NEEDS"
+          exit 1
 
   committed:
     name: Committed


### PR DESCRIPTION
The gate job's `if:` carried no status function, so GitHub applied an implicit `success()` over its `needs` and skipped the job whenever a dependency failed. Since a skipped required check counts as satisfied, the gate reported green in exactly the case it existed to catch — this is how #1459 auto-merged with a failing typecheck.

The job now always runs and fails the run if any dependency did not succeed, so `skipped` is no longer a reachable conclusion for the required check.