### PR TITLE
fix(stats): surface GitHub API error details

### DIFF
--- a/app/lib/github-stats.test.ts
+++ b/app/lib/github-stats.test.ts
@@ -1,16 +1,19 @@
 // biome-ignore-all lint/style/useNamingConvention: test fixtures mirror the GitHub API response shape
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import fallbackJson from "../data/github-stats-fallback.json" with {
   type: "json",
 };
 import {
   contributionWindow,
   fallbackGithubStats,
+  fetchGithubStats,
   parseActivityItems,
   parseContributionTotals,
 } from "./github-stats.ts";
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/u;
+const BAD_CREDENTIALS_RE = /401.*Bad credentials/u;
+const SCOPE_ERROR_RE = /Resource not accessible by personal access token/u;
 
 // MARK: parseContributionTotals
 
@@ -317,5 +320,47 @@ describe("fallbackGithubStats", () => {
 
     expect(periodFrom).toMatch(DATE_RE);
     expect(periodTo).toMatch(DATE_RE);
+  });
+});
+
+// MARK: transport errors
+
+describe("fetchGithubStats transport errors", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("surfaces the body message when GitHub rejects the token", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ message: "Bad credentials" }), {
+          status: 401,
+        }),
+      ),
+    );
+
+    await expect(fetchGithubStats("expired")).rejects.toThrow(
+      BAD_CREDENTIALS_RE,
+    );
+  });
+
+  test("surfaces GraphQL errors returned with a 200", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            data: { user: null },
+            errors: [
+              { message: "Resource not accessible by personal access token" },
+            ],
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+
+    await expect(fetchGithubStats("scopeless")).rejects.toThrow(SCOPE_ERROR_RE);
   });
 });

--- a/app/lib/github-stats.ts
+++ b/app/lib/github-stats.ts
@@ -162,6 +162,34 @@ function classifyActivityItem(i: Record<string, unknown>): {
 
 // MARK: Transport
 
+/**
+ * Extracts a human-readable reason from a GitHub error response, so a failure
+ * says "401: Bad credentials" rather than a bare status code.
+ */
+async function failureDetail(resp: Response): Promise<string> {
+  try {
+    const body = (await resp.json()) as { message?: unknown };
+    if (typeof body.message === "string" && body.message) {
+      return `: ${body.message}`;
+    }
+  } catch {
+    // Body was not JSON; the status alone will have to do.
+  }
+  return "";
+}
+
+/**
+ * Collapses a GraphQL `errors` array into a single message. GitHub reports
+ * scope and permission problems this way *with a 200 status*, so these must be
+ * checked explicitly or they surface later as confusing parse failures.
+ */
+function graphqlErrorMessage(errors: unknown[]): string {
+  const messages = errors
+    .map((e) => (e as { message?: unknown }).message)
+    .filter((m): m is string => typeof m === "string");
+  return messages.length > 0 ? messages.join("; ") : "unknown GraphQL error";
+}
+
 async function graphql(
   query: string,
   token: string,
@@ -177,9 +205,17 @@ async function graphql(
     body: JSON.stringify({ query }),
   });
   if (!resp.ok) {
-    throw new Error(`GraphQL status ${resp.status}`);
+    throw new Error(
+      `GraphQL status ${resp.status}${await failureDetail(resp)}`,
+    );
   }
-  return resp.json() as Promise<Record<string, unknown>>;
+
+  const body = (await resp.json()) as Record<string, unknown>;
+  const { errors } = body;
+  if (Array.isArray(errors) && errors.length > 0) {
+    throw new Error(`GraphQL error: ${graphqlErrorMessage(errors)}`);
+  }
+  return body;
 }
 
 async function restGet(
@@ -196,7 +232,7 @@ async function restGet(
     },
   });
   if (!resp.ok) {
-    throw new Error(`REST status ${resp.status}`);
+    throw new Error(`REST status ${resp.status}${await failureDetail(resp)}`);
   }
   return resp.json();
 }


### PR DESCRIPTION
A failing stats refresh reported only a bare status code, and GraphQL
scope errors were missed entirely: GitHub returns those with a 200 and an
`errors` array, so they surfaced later as a confusing "totalContributions
missing" parse failure rather than an auth problem.

Check the `errors` array explicitly and include the response body's
message in transport errors, so an expired token reads as
"GraphQL status 401: Bad credentials".

Assisted-by: Claude Code:claude-opus-5[1m]

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>