### PR TITLE
fix(stats): log background refresh failures

### DIFF
--- a/app/lib/stats-cache.test.ts
+++ b/app/lib/stats-cache.test.ts
@@ -1,5 +1,9 @@
-import { expect, test, vi } from "vitest";
+import { afterEach, expect, test, vi } from "vitest";
 import { readWithSWR } from "./stats-cache.ts";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 function fakeKv(initial: Record<string, string>) {
   const store = new Map(Object.entries(initial));
@@ -51,4 +55,28 @@ test("returns stale data and schedules background refresh", async () => {
   expect(waits.length).toBe(1);
   await Promise.all(waits);
   expect(JSON.parse(kv._store.get("s") as string).data).toBe(2);
+});
+
+test("a failing refresh is reported and never rejects", async () => {
+  const kv = fakeKv({});
+  const err = new Error("GraphQL status 401");
+  const refresh = vi.fn().mockRejectedValue(err);
+  const logged = vi.spyOn(console, "error").mockImplementation(() => undefined);
+  const waits: Promise<unknown>[] = [];
+
+  const r = await readWithSWR({
+    kv,
+    key: "fail-reported",
+    maxAgeMs: 10_000,
+    refresh,
+    waitUntil: (p) => waits.push(p),
+    now: () => 1000,
+  });
+
+  expect(r).toEqual({ data: null, stale: false });
+  await expect(Promise.all(waits)).resolves.toBeDefined();
+  expect(logged).toHaveBeenCalledWith(
+    expect.stringContaining("fail-reported"),
+    err,
+  );
 });

--- a/app/lib/stats-cache.ts
+++ b/app/lib/stats-cache.ts
@@ -27,7 +27,11 @@ export async function readWithSWR<T>(opts: {
             opts.key,
             JSON.stringify({ data, fetchedAt: now } satisfies CachedStats<T>),
           ),
-        ),
+        )
+        .catch((err: unknown) => {
+          // biome-ignore lint/suspicious/noConsole: Worker observability captures console output; this is the only signal that a background refresh is failing.
+          console.error(`[stats-cache] refresh failed for "${opts.key}":`, err);
+        }),
     );
   }
   return { data: cached?.data ?? null, stale: cached !== null && !fresh };


### PR DESCRIPTION
The SWR refresh promise handed to waitUntil had no rejection handler, so
a failing refresh was discarded in silence. An expired GitHub token left
the cache permanently unwritten and every page quietly served the
build-time fallback, with nothing in the logs to say so.

Attach a catch that reports the failing key. Worker observability is
already enabled, so this now surfaces in the dashboard and wrangler tail.

Assisted-by: Claude Code:claude-opus-5[1m]

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>