### PR TITLE
fix(stats): single-flight and back off refreshes

### DIFF
--- a/app/lib/stats-cache.test.ts
+++ b/app/lib/stats-cache.test.ts
@@ -80,3 +80,60 @@ test("a failing refresh is reported and never rejects", async () => {
     err,
   );
 });
+
+test("concurrent misses share a single refresh", async () => {
+  const kv = fakeKv({});
+  let resolveRefresh: ((v: number) => void) | undefined;
+  const refresh = vi.fn(
+    () =>
+      new Promise<number>((res) => {
+        resolveRefresh = res;
+      }),
+  );
+  const waits: Promise<unknown>[] = [];
+  const read = () =>
+    readWithSWR({
+      kv,
+      key: "single-flight",
+      maxAgeMs: 10_000,
+      refresh,
+      waitUntil: (p) => waits.push(p),
+      now: () => 1000,
+    });
+
+  await Promise.all([read(), read(), read()]);
+  resolveRefresh?.(7);
+  await Promise.all(waits);
+
+  expect(refresh).toHaveBeenCalledTimes(1);
+  expect(JSON.parse(kv._store.get("single-flight") as string).data).toBe(7);
+});
+
+test("a failed refresh is not retried until the cooldown expires", async () => {
+  const kv = fakeKv({});
+  const refresh = vi.fn().mockRejectedValue(new Error("boom"));
+  vi.spyOn(console, "error").mockImplementation(() => undefined);
+  const waits: Promise<unknown>[] = [];
+  const read = (now: number) =>
+    readWithSWR({
+      kv,
+      key: "cooldown",
+      maxAgeMs: 10_000,
+      refresh,
+      waitUntil: (p) => waits.push(p),
+      cooldownMs: 60_000,
+      now: () => now,
+    });
+
+  await read(1000);
+  await Promise.all(waits);
+  expect(refresh).toHaveBeenCalledTimes(1);
+
+  await read(30_000);
+  await Promise.all(waits);
+  expect(refresh).toHaveBeenCalledTimes(1);
+
+  await read(61_001);
+  await Promise.all(waits);
+  expect(refresh).toHaveBeenCalledTimes(2);
+});

--- a/app/lib/stats-cache.ts
+++ b/app/lib/stats-cache.ts
@@ -1,38 +1,88 @@
+interface Kv {
+  get: (k: string, t?: "json") => Promise<unknown>;
+  put: (k: string, v: string) => Promise<void>;
+}
+
+interface RefreshOpts<T> {
+  kv: Kv;
+  key: string;
+  refresh: () => Promise<T>;
+  waitUntil: (p: Promise<unknown>) => void;
+  cooldownMs?: number;
+  now?: () => number;
+}
+
+/**
+ * How long to wait before retrying a key whose refresh threw. Without this a
+ * persistently failing upstream is retried on every single request, which both
+ * hammers the API and guarantees it keeps failing.
+ */
+const DEFAULT_COOLDOWN_MS = 60_000;
+
+/** Refreshes currently running in this isolate, keyed by cache key. */
+const inFlight = new Map<string, Promise<unknown>>();
+
+/** Earliest time a key may be refreshed again after a failure, keyed by cache key. */
+const retryAfter = new Map<string, number>();
+
+function scheduleRefresh<T>(opts: RefreshOpts<T>, now: number): void {
+  const { key } = opts;
+
+  const blockedUntil = retryAfter.get(key);
+  if (blockedUntil !== undefined && now < blockedUntil) {
+    return;
+  }
+
+  const running = inFlight.get(key);
+  if (running) {
+    opts.waitUntil(running);
+    return;
+  }
+
+  const clock = opts.now ?? Date.now;
+  const pending = opts
+    .refresh()
+    .then((data) =>
+      opts.kv.put(
+        key,
+        JSON.stringify({
+          data,
+          fetchedAt: clock(),
+        } satisfies CachedStats<T>),
+      ),
+    )
+    .then(() => {
+      retryAfter.delete(key);
+    })
+    .catch((err: unknown) => {
+      retryAfter.set(key, now + (opts.cooldownMs ?? DEFAULT_COOLDOWN_MS));
+      // biome-ignore lint/suspicious/noConsole: Worker observability captures console output; this is the only signal that a background refresh is failing.
+      console.error(`[stats-cache] refresh failed for "${key}":`, err);
+    })
+    .finally(() => {
+      if (inFlight.get(key) === pending) {
+        inFlight.delete(key);
+      }
+    });
+
+  inFlight.set(key, pending);
+  opts.waitUntil(pending);
+}
+
 export interface CachedStats<T> {
   data: T;
   fetchedAt: number;
 }
 
 // biome-ignore lint/style/useNamingConvention: SWR = stale-while-revalidate (domain acronym)
-export async function readWithSWR<T>(opts: {
-  kv: {
-    get: (k: string, t?: "json") => Promise<unknown>;
-    put: (k: string, v: string) => Promise<void>;
-  };
-  key: string;
-  maxAgeMs: number;
-  refresh: () => Promise<T>;
-  waitUntil: (p: Promise<unknown>) => void;
-  now?: () => number;
-}): Promise<{ data: T | null; stale: boolean }> {
+export async function readWithSWR<T>(
+  opts: RefreshOpts<T> & { maxAgeMs: number },
+): Promise<{ data: T | null; stale: boolean }> {
   const now = (opts.now ?? Date.now)();
   const cached = (await opts.kv.get(opts.key, "json")) as CachedStats<T> | null;
   const fresh = cached !== null && now - cached.fetchedAt < opts.maxAgeMs;
   if (!(cached && fresh)) {
-    opts.waitUntil(
-      opts
-        .refresh()
-        .then((data) =>
-          opts.kv.put(
-            opts.key,
-            JSON.stringify({ data, fetchedAt: now } satisfies CachedStats<T>),
-          ),
-        )
-        .catch((err: unknown) => {
-          // biome-ignore lint/suspicious/noConsole: Worker observability captures console output; this is the only signal that a background refresh is failing.
-          console.error(`[stats-cache] refresh failed for "${opts.key}":`, err);
-        }),
-    );
+    scheduleRefresh(opts, now);
   }
   return { data: cached?.data ?? null, stale: cached !== null && !fresh };
 }


### PR DESCRIPTION
With the cache empty, every request fired its own refresh: four GitHub
calls, three against the 30/min search endpoint. A cold cache could
therefore rate-limit itself and never recover, since only a successful
refresh ever writes the entry that would stop the stampede.

Share one in-flight refresh per key, and after a failure hold off before
retrying so a broken upstream is probed occasionally rather than on every
request. Both guards are per-isolate, which is where the pile-up happens.

Also stamp fetchedAt when the write happens rather than when the read
started, so a slow refresh is not recorded as older than it is.

Assisted-by: Claude Code:claude-opus-5[1m]

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>