### PR TITLE
fix(stats): log fallback use on SSR pages

### DIFF
--- a/app/pages/api/github-stats.ts
+++ b/app/pages/api/github-stats.ts
@@ -17,7 +17,9 @@ export const GET: APIRoute = async () => {
       stats =
         (cached?.data as GitHubStats | undefined) ?? fallbackGithubStats();
     }
-  } catch {
+  } catch (err) {
+    // biome-ignore lint/suspicious/noConsole: Worker observability captures console output; a silent fallback hides a broken refresh.
+    console.error("[api/github-stats] KV read failed, using fallback:", err);
     stats = fallbackGithubStats();
   }
   return Response.json(stats);

--- a/app/pages/index.astro
+++ b/app/pages/index.astro
@@ -35,7 +35,9 @@ async function loadStats() {
       waitUntil,
     });
     return data ?? fallbackGithubStats();
-  } catch {
+  } catch (err) {
+    // biome-ignore lint/suspicious/noConsole: Worker observability captures console output; silent fallback is what hid a 6-week stats outage.
+    console.error("[home] GitHub stats unavailable, using fallback:", err);
     return fallbackGithubStats();
   }
 }

--- a/app/pages/projects.astro
+++ b/app/pages/projects.astro
@@ -35,7 +35,9 @@ async function loadProjectStats() {
       waitUntil,
     });
     return data && data.repos.length > 0 ? data : fallbackProjectStats();
-  } catch {
+  } catch (err) {
+    // biome-ignore lint/suspicious/noConsole: Worker observability captures console output; a silent fallback hides a broken refresh.
+    console.error("[projects] stats unavailable, using fallback:", err);
     return fallbackProjectStats();
   }
 }

--- a/app/pages/projects/[slug].astro
+++ b/app/pages/projects/[slug].astro
@@ -47,7 +47,9 @@ async function loadProjectStats() {
       waitUntil,
     });
     return data && data.repos.length > 0 ? data : fallbackProjectStats();
-  } catch {
+  } catch (err) {
+    // biome-ignore lint/suspicious/noConsole: Worker observability captures console output; a silent fallback hides a broken refresh.
+    console.error(`[project:${slug}] stats unavailable, using fallback:`, err);
     return fallbackProjectStats();
   }
 }


### PR DESCRIPTION
Every page reading GitHub stats wrapped the lookup in a bare catch, so a
missing binding or a KV read error was indistinguishable from healthy
operation: the page rendered fine on baked-in fallback data and said
nothing. Report the error before falling back.

Assisted-by: Claude Code:claude-opus-5[1m]

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>